### PR TITLE
better error message for app not found

### DIFF
--- a/v2.yml
+++ b/v2.yml
@@ -236,7 +236,7 @@
 100004:
   name: AppNotFound
   http_code: 404
-  message: "The app name could not be found: %s"
+  message: "Could not find app: %s"
 
 100005:
   name: AppMemoryQuotaExceeded


### PR DESCRIPTION
"app name could not be found" is incorrect, since this is often thrown when an app cannot be found for a given guid. "name" is not relevant in this situation.
