### PR TITLE
Fix for https://www.pivotaltracker.com/s/projects/166935/stories/48602149

### DIFF
--- a/v2.yml
+++ b/v2.yml
@@ -46,7 +46,7 @@
 10006:
   name: AssociationNotEmpty
   http_code: 400
-  message: "Please delete the %s associations for your %s."
+  message: "%s is not empty. To delete, please remove the following associations: %s."
 
 20001:
   name: UserInvalid


### PR DESCRIPTION
Cloud controller should return better error message when user tries to delete non-empty Space, Organization or any other objects which have dependencies. Current error message on this clunky and ungrammatical. Related to the 48602149 in Pivotal tracker
https://www.pivotaltracker.com/s/projects/166935/stories/48602149

Also related PR from cloud contoller module 
https://github.com/cloudfoundry/cloud_controller_ng/pull/102

Related PR from yeti tests
cloudfoundry/vcap-yeti#15
