### PR TITLE
Add BuildpackLocked error

### DIFF
--- a/v2.yml
+++ b/v2.yml
@@ -477,3 +477,8 @@
   name: CustomBuildpacksDisabled
   http_code: 400
   message: "Custom buildpacks are disabled"
+
+290005:
+  name: BuildpackLocked
+  http_code: 409
+  message: "The buildpack is locked"


### PR DESCRIPTION
This adds an error code for when a change is attempted on a locked buildpack.

This is a pre-requisite this PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/149
