### PR TITLE
CC should reject apps that specify both a custom buildpack and a docker image

### DIFF
--- a/v2.yml
+++ b/v2.yml
@@ -618,6 +618,11 @@
   http_code: 400
   message: Diego has not been enabled.
 
+320002:
+  name: DiegoDockerBuildpackConflict
+  http_code: 400
+  message: "You cannot specify a custom buildpack and a docker image at the same time."
+
 330000:
   name: FeatureFlagNotFound
   http_code: 404


### PR DESCRIPTION
Updated submodule vendor/errors in cloud_controller_ng. 

https://www.pivotaltracker.com/story/show/75859568

/cc @onsi
